### PR TITLE
Support JSON for cli --dev-ware and --hot-client

### DIFF
--- a/lib/flags.js
+++ b/lib/flags.js
@@ -23,6 +23,9 @@ module.exports = {
     const result = Object.assign({}, argv);
     const https = parseGroup(argv, 'https');
     const open = parseGroup(argv, 'open');
+    // Allow to pass devWare and hotClient params as JSON
+    if (typeof argv.devWare === 'string') argv.devWare = JSON.parse(argv.devWare);
+    if (typeof argv.hotClient === 'string') argv.hotClient = JSON.parse(argv.hotClient);
     const devMiddleware = argv.devWare || {};
     const hotClient = argv.hotClient || {};
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

In v1 you were able to pass JSON into `--dev-ware` and `--hot-client`

In v2 you can't do it anymore and passing something like this is pretty much impossible:
```json
{
  "publicPath": "/build/client/",
  "headers": {
    "Access-Control-Allow-Origin": "*"
  }
}
```

Now you can pass it through cli the same way it was possible in v1:
```bash
webpack-serve --dev-ware '{\"publicPath\":\"/build/client/\",\"headers\":{\"Access-Control-Allow-Origin\":\"*\"}}'
```

### Breaking Changes

No breaking changes. On the contrary, it brings back the v1 API support.